### PR TITLE
修复 支付宝支付 返回的结果

### DIFF
--- a/app/Http/Controllers/Ali/AliPayController.php
+++ b/app/Http/Controllers/Ali/AliPayController.php
@@ -44,16 +44,7 @@ class AliPayController extends Controller implements Pay {
 
         Log::info("订单： " . $payInfo['order_num'] . "  支付宝支付返回结果： " . json_encode($response));
 
-        $responseNode = str_replace(".", "_", $request->getApiMethodName()) . "_response";
-
-        $resultCode = $response->$responseNode->code;
-
-        if(!empty($resultCode) && $resultCode == 10000){
-            return $response;
-        } else {
-            Log::error("订单： " . $payInfo['order_num'] . "  支付宝支付失败");
-            return false;
-        }
+        return $response;
 
     }
 


### PR DESCRIPTION
支付宝支付返回的结果是一段字符串，用于给前端调起支付宝时需要的参数，而 SDK 上的 json 判断是不对的